### PR TITLE
#40080 #39292 #38927 Transparent icons/Project setup menu item

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -13,7 +13,7 @@
 
 location:
   path: https://github.com/shotgunsoftware/tk-core.git
-  version: 62ecc6538c964a379c5564fe3168c1880103661b
+  version: 6010c03215c7420bd784752527ff4730f05624c2
   type: git_branch
   branch: develop/zero_config
 

--- a/env/includes/common/frameworks.yml
+++ b/env/includes/common/frameworks.yml
@@ -25,7 +25,7 @@ frameworks:
       name: tk-framework-shotgunutils
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.0.1
+      version: v5.1.0
       type: app_store
       name: tk-framework-shotgunutils
   tk-framework-adminui_v0.x.x:

--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -21,7 +21,7 @@ desktop.project:
       use_software_entity: true
       location:
         path: https://github.com/shotgunsoftware/tk-multi-launchapp.git
-        version: d0185eb5ac6c7a00e52af078c17a2fa646bd040c
+        version: 058447a6f482757c9194f7f595e6ca755e337c54
         type: git_branch
         branch: develop/software_entity
   collapse_rules:
@@ -46,6 +46,6 @@ desktop.project:
     name: Finishing Tools
   location:
     path: https://github.com/shotgunsoftware/tk-desktop.git
-    version: a5f0035ca93699b5bdbf2b62f55a62150990909f
+    version: e19620bcf4448fa0c7da3014cc60ff26a2ddae90
     type: git_branch
     branch: develop/zero_config

--- a/env/includes/desktop/site.yml
+++ b/env/includes/desktop/site.yml
@@ -19,6 +19,6 @@ desktop.site:
   apps:
   location:
     path: https://github.com/shotgunsoftware/tk-desktop.git
-    version: a5f0035ca93699b5bdbf2b62f55a62150990909f
+    version: e19620bcf4448fa0c7da3014cc60ff26a2ddae90
     type: git_branch
     branch: develop/zero_config

--- a/env/includes/shell/all.yml
+++ b/env/includes/shell/all.yml
@@ -21,7 +21,7 @@ shell.all:
       use_software_entity: true
       location:
         path: https://github.com/shotgunsoftware/tk-multi-launchapp.git
-        version: d0185eb5ac6c7a00e52af078c17a2fa646bd040c
+        version: 058447a6f482757c9194f7f595e6ca755e337c54
         type: git_branch
         branch: develop/software_entity
   location:


### PR DESCRIPTION
Commit versions of zero_config branches for tk-core, tk-desktop, and tk-multi-launchapp that address #40080, #39292, and #38927.  This mainly addresses support for Software icon transparency and a new "Advanced project setup..." user menu item in Desktop that launches the Toolkit Project Setup wizard. 
