### PR TITLE
For #40549, Updated tk-config-basic branch versions

### DIFF
--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -21,7 +21,7 @@ desktop.project:
       use_software_entity: true
       location:
         path: https://github.com/shotgunsoftware/tk-multi-launchapp.git
-        version: b49c01e46de1ab1ae887c371bdd05b2454d8b6f3
+        version: 9486141f58064c37ed43157b90a16accfe3e67fd
         type: git_branch
         branch: develop/software_entity
   collapse_rules:
@@ -46,6 +46,6 @@ desktop.project:
     name: Finishing Tools
   location:
     path: https://github.com/shotgunsoftware/tk-desktop.git
-    version: 4caecc868ebf53d240c4d4a0672e444c130c6bb3
+    version: 76dcdb188f51e50ee94dafb44b899d3f4a0b8bc3
     type: git_branch
     branch: develop/zero_config

--- a/env/includes/desktop/site.yml
+++ b/env/includes/desktop/site.yml
@@ -19,6 +19,6 @@ desktop.site:
   apps:
   location:
     path: https://github.com/shotgunsoftware/tk-desktop.git
-    version: 4caecc868ebf53d240c4d4a0672e444c130c6bb3
+    version: 76dcdb188f51e50ee94dafb44b899d3f4a0b8bc3
     type: git_branch
     branch: develop/zero_config

--- a/env/includes/maya/project.yml
+++ b/env/includes/maya/project.yml
@@ -76,7 +76,7 @@ maya.project:
           filters: {}
   location:
     path: https://github.com/shotgunsoftware/tk-maya.git
-    version: c934fb5326c72be023f454b8a78a8002dece4d7c
+    version: 1241a127b312da3c7395d4fa1dc18556083ceb01
     type: git_branch
     branch: develop/zero_config
   menu_favourites: []

--- a/env/includes/maya/site.yml
+++ b/env/includes/maya/site.yml
@@ -69,7 +69,7 @@ maya.site:
           filters: {}
   location:
     path: https://github.com/shotgunsoftware/tk-maya.git
-    version: c934fb5326c72be023f454b8a78a8002dece4d7c
+    version: 1241a127b312da3c7395d4fa1dc18556083ceb01
     type: git_branch
     branch: develop/zero_config
   menu_favourites: []

--- a/env/includes/shell/all.yml
+++ b/env/includes/shell/all.yml
@@ -21,7 +21,7 @@ shell.all:
       use_software_entity: true
       location:
         path: https://github.com/shotgunsoftware/tk-multi-launchapp.git
-        version: 058447a6f482757c9194f7f595e6ca755e337c54
+        version: 9486141f58064c37ed43157b90a16accfe3e67fd
         type: git_branch
         branch: develop/software_entity
   location:


### PR DESCRIPTION
This adds command grouping functionality in tk-desktop and tk-multi-launch command.  Rather than seeing one launch button per version of a DCC application, the end user should see one launch button for the DCC, and drop-down menu items to select specific versions of the DCC.  The highest version is currently used as the default in tk-desktop.