### PR TITLE
For #43560: Fix Publish() method not handling None vs. zero differently

### DIFF
--- a/hooks/tk-multi-publish2/3dsmax.basic/publish_max_session.py
+++ b/hooks/tk-multi-publish2/3dsmax.basic/publish_max_session.py
@@ -296,7 +296,10 @@ class MaxSessionPublishPlugin(HookBaseClass):
         publish_name = publisher.util.get_publish_name(path)
 
         # extract the version number for publishing. use 1 if no version in path
-        version_number = publisher.util.get_version_number(path) or 1
+        # also make sure we are handling None and 0 differently
+        version_number = publisher.util.get_version_number(path)
+        if version_number is None:
+            version_number = 1
 
         # arguments for publish registration
         self.logger.info("Registering publish...")

--- a/hooks/tk-multi-publish2/houdini.basic/publish_houdini_session.py
+++ b/hooks/tk-multi-publish2/houdini.basic/publish_houdini_session.py
@@ -296,7 +296,10 @@ class HoudiniSessionPublishPlugin(HookBaseClass):
         publish_name = publisher.util.get_publish_name(path)
 
         # extract the version number for publishing. use 1 if no version in path
-        version_number = publisher.util.get_version_number(path) or 1
+        # also make sure we are handling None and 0 differently
+        version_number = publisher.util.get_version_number(path)
+        if version_number is None:
+            version_number = 1
 
         # arguments for publish registration
         self.logger.info("Registering publish...")

--- a/hooks/tk-multi-publish2/maya.basic/publish_maya_session.py
+++ b/hooks/tk-multi-publish2/maya.basic/publish_maya_session.py
@@ -316,7 +316,10 @@ class MayaSessionPublishPlugin(HookBaseClass):
         publish_name = publisher.util.get_publish_name(path)
 
         # extract the version number for publishing. use 1 if no version in path
-        version_number = publisher.util.get_version_number(path) or 1
+        # also make sure we are handling None and 0 differently
+        version_number = publisher.util.get_version_number(path)
+        if version_number is None:
+            version_number = 1
 
         # arguments for publish registration
         self.logger.info("Registering publish...")

--- a/hooks/tk-multi-publish2/nuke.basic/nuke_publish_script.py
+++ b/hooks/tk-multi-publish2/nuke.basic/nuke_publish_script.py
@@ -296,7 +296,10 @@ class NukeSessionPublishPlugin(HookBaseClass):
         publish_name = publisher.util.get_publish_name(path)
 
         # extract the version number for publishing. use 1 if no version in path
-        version_number = publisher.util.get_version_number(path) or 1
+        # also make sure we are handling None and 0 differently
+        version_number = publisher.util.get_version_number(path)
+        if version_number is None:
+            version_number = 1
 
         # arguments for publish registration
         self.logger.info("Registering publish...")

--- a/hooks/tk-multi-publish2/nuke.basic/nukestudio_publish_project.py
+++ b/hooks/tk-multi-publish2/nuke.basic/nukestudio_publish_project.py
@@ -306,7 +306,10 @@ class NukeStudioProjectPublishPlugin(HookBaseClass):
         publish_name = publisher.util.get_publish_name(path)
 
         # extract the version number for publishing. use 1 if no version in path
-        version_number = publisher.util.get_version_number(path) or 1
+        # also make sure we are handling None and 0 differently
+        version_number = publisher.util.get_version_number(path)
+        if version_number is None:
+            version_number = 1
 
         # arguments for publish registration
         self.logger.info("Registering publish...")

--- a/hooks/tk-multi-publish2/photoshopcc.basic/publish_photoshop_document.py
+++ b/hooks/tk-multi-publish2/photoshopcc.basic/publish_photoshop_document.py
@@ -315,7 +315,10 @@ class PhotoshopCCDocumentPublishPlugin(HookBaseClass):
         publish_name = publisher.util.get_publish_name(path)
 
         # extract the version number for publishing. use 1 if no version in path
-        version_number = publisher.util.get_version_number(path) or 1
+        # also make sure we are handling None and 0 differently
+        version_number = publisher.util.get_version_number(path)
+        if version_number is None:
+            version_number = 1
 
         path_info = publisher.util.get_file_path_components(path)
         extension = path_info["extension"]


### PR DESCRIPTION
Sorry bugging you again with this trivial bug but I wasn't expecting I would need to duplicate the same fix accross so many different files. I understand the nature of the DCC code is making difficult to completely avoid some code duplication.

I did look into possibly changing the ouput of `publisher.util.get_version_number(path)` to include None. I wasn't sure changing the output would be safe throughout the entire DCCs, in any case several files would still be updated. Let me know what you think.