### PR TITLE
#46126 Added flame publish types to nuke loader/panel

### DIFF
--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -40,15 +40,15 @@ nuke.apps.tk-multi-publish2:
 nuke.apps.tk-multi-loader2:
   action_mappings:
     Alembic Cache: [read_node]
-    Image: [read_node]
-    Movie: [read_node]
     Flame Render: [read_node]
     Flame Quicktime: [read_node]
+    Image: [read_node]
+    Movie: [read_node]
+    Nuke Script: [script_import]
+    NukeStudio Project: [open_project]
     Photoshop Image: [read_node]
     Rendered Image: [read_node]
     Texture: [read_node]
-    Nuke Script: [script_import]
-    NukeStudio Project: [open_project]
   actions_hook: '{self}/tk-nuke_actions.py'
   entities:
   - caption: Current Project

--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -42,11 +42,13 @@ nuke.apps.tk-multi-loader2:
     Alembic Cache: [read_node]
     Image: [read_node]
     Movie: [read_node]
-    Nuke Script: [script_import]
-    NukeStudio Project: [open_project]
+    Flame Render: [read_node]
+    Flame Quicktime: [read_node]
     Photoshop Image: [read_node]
     Rendered Image: [read_node]
     Texture: [read_node]
+    Nuke Script: [script_import]
+    NukeStudio Project: [open_project]
   actions_hook: '{self}/tk-nuke_actions.py'
   entities:
   - caption: Current Project
@@ -76,6 +78,10 @@ nuke.apps.tk-multi-shotgunpanel:
       filters: {published_file_type: Image}
     - actions: [read_node]
       filters: {published_file_type: Movie}
+    - actions: [read_node]
+      filters: {published_file_type: Flame Render}
+    - actions: [read_node]
+      filters: {published_file_type: Flame Quicktime}
     - actions: [script_import]
       filters: {published_file_type: Nuke Script}
     - actions: [open_project]

--- a/env/includes/nuke/site.yml
+++ b/env/includes/nuke/site.yml
@@ -27,6 +27,8 @@ nuke.site:
         Alembic Cache: [read_node]
         Image: [read_node]
         Movie: [read_node]
+        Flame Render: [read_node]
+        Flame Quicktime: [read_node]
         Nuke Script: [script_import]
         NukeStudio Project: [open_project]
         Photoshop Image: [read_node]

--- a/env/includes/nuke/site.yml
+++ b/env/includes/nuke/site.yml
@@ -25,10 +25,10 @@ nuke.site:
     tk-multi-loader2:
       action_mappings:
         Alembic Cache: [read_node]
-        Image: [read_node]
-        Movie: [read_node]
         Flame Render: [read_node]
         Flame Quicktime: [read_node]
+        Image: [read_node]
+        Movie: [read_node]
         Nuke Script: [script_import]
         NukeStudio Project: [open_project]
         Photoshop Image: [read_node]


### PR DESCRIPTION
This add zero config support for the two publish types `Flame Render` and `Flame Quicktime`, allowing renders published from flame to be picked up by the std toolkit integrations.