### PR TITLE
For #46098: Adds flame clip update publish plugin configuration.

### DIFF
--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -31,11 +31,9 @@ common.engines.tk-maya.location:
 
 # Nuke
 common.engines.tk-nuke.location:
-    # type: app_store
-    # name: tk-nuke
-    # version: v0.9.4
-    type: dev
-    path: /git/tk-nuke
+    type: app_store
+    name: tk-nuke
+    version: v0.9.4
 
 # Photoshop
 common.engines.tk-photoshopcc.location:

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -31,9 +31,11 @@ common.engines.tk-maya.location:
 
 # Nuke
 common.engines.tk-nuke.location:
-    type: app_store
-    name: tk-nuke
-    version: v0.9.4
+    # type: app_store
+    # name: tk-nuke
+    # version: v0.9.4
+    type: dev
+    path: /git/tk-nuke
 
 # Photoshop
 common.engines.tk-photoshopcc.location:

--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -35,6 +35,9 @@ nuke.apps.tk-multi-publish2:
     - name: Publish to Shotgun
       hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nukestudio_publish_project.py"
       settings: {}
+    - name: Update Flame Clip
+      hook: "{engine}/tk-multi-publish2/basic/nuke_update_flame_clip.py"
+      settings: {}
   location: "@common.apps.tk-multi-publish2.location"
 
 nuke.apps.tk-multi-loader2:


### PR DESCRIPTION
The nuke_update_flame_clip plugin will now work in zero config projects. As a such, it's been added to the publish2 plugin list for Nuke.