### PR TITLE
For SG-4609: Adds a tk-nukestudio instance without quickreview included.

### DIFF
--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -33,6 +33,7 @@ desktop.project:
 
     tk-multi-launchapp:
       use_software_entity: true
+      hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
       location: "@common.apps.tk-multi-launchapp.location"
 
   collapse_rules:

--- a/env/includes/nuke/project.yml
+++ b/env/includes/nuke/project.yml
@@ -35,3 +35,20 @@ nuke.project:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
   launch_builtin_plugins: [basic]
   automatic_context_switch: false
+
+nukestudio.project:
+  apps:
+    tk-multi-about: '@common.apps.tk-multi-about'
+
+    tk-multi-publish2: '@nuke.apps.tk-multi-publish2'
+
+    tk-multi-loader2: '@nuke.apps.tk-multi-loader2'
+
+    tk-multi-shotgunpanel: '@nuke.apps.tk-multi-shotgunpanel'
+
+  location: "@common.engines.tk-nuke.location"
+  menu_favourites: []
+  run_at_startup:
+  - {app_instance: tk-multi-shotgunpanel, name: ''}
+  launch_builtin_plugins: [basic]
+  automatic_context_switch: false

--- a/env/includes/nuke/shot.yml
+++ b/env/includes/nuke/shot.yml
@@ -38,3 +38,22 @@ nuke.shot:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
   launch_builtin_plugins: [basic]
   automatic_context_switch: false
+
+nukestudio.shot:
+  apps:
+    tk-multi-about: '@common.apps.tk-multi-about'
+
+    tk-multi-setframerange: '@common.apps.tk-multi-setframerange'
+
+    tk-multi-publish2: '@nuke.apps.tk-multi-publish2'
+
+    tk-multi-loader2: '@nuke.apps.tk-multi-loader2'
+
+    tk-multi-shotgunpanel: '@nuke.apps.tk-multi-shotgunpanel'
+
+  location: "@common.engines.tk-nuke.location"
+  menu_favourites: []
+  run_at_startup:
+  - {app_instance: tk-multi-shotgunpanel, name: ''}
+  launch_builtin_plugins: [basic]
+  automatic_context_switch: false

--- a/env/includes/nuke/shot.yml
+++ b/env/includes/nuke/shot.yml
@@ -51,6 +51,8 @@ nukestudio.shot:
 
     tk-multi-shotgunpanel: '@nuke.apps.tk-multi-shotgunpanel'
 
+    tk-nuke-quickreview: '@nuke.apps.tk-nuke-quickreview'
+
   location: "@common.engines.tk-nuke.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/shell/apps.yml
+++ b/env/includes/shell/apps.yml
@@ -19,6 +19,7 @@ includes:
 
 shell.apps.tk-multi-launchapp:
   use_software_entity: true
+  hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
   location: "@common.apps.tk-multi-launchapp.location"
 
 shell.apps.tk-multi-publish2:

--- a/env/includes/shotgun/all.yml
+++ b/env/includes/shotgun/all.yml
@@ -31,6 +31,7 @@ shotgun.all:
     tk-multi-launchapp:
       scan_all_projects: true
       use_software_entity: true
+      hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
       location: "@common.apps.tk-multi-launchapp.location"
 
   location: "@common.engines.tk-shotgun.location"

--- a/env/project.yml
+++ b/env/project.yml
@@ -27,6 +27,7 @@ engines:
   tk-houdini: '@houdini.project'
   tk-maya: '@maya.project'
   tk-nuke: '@nuke.project'
+  tk-nukestudio: '@nukestudio.project'
   tk-desktop: '@desktop.project'
   tk-shell: '@shell.project'
   tk-photoshopcc: '@photoshopcc.project'

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -26,6 +26,7 @@ engines:
   tk-houdini: '@houdini.shot'
   tk-maya: '@maya.shot'
   tk-nuke: '@nuke.shot'
+  tk-nukestudio: '@nukestudio.shot'
   tk-flame: '@flame.shot'
   tk-shell: '@shell.shot'
   tk-photoshopcc: '@photoshopcc.shot'

--- a/env/site.yml
+++ b/env/site.yml
@@ -27,6 +27,7 @@ engines:
   tk-houdini: '@houdini.site'
   tk-maya: '@maya.site'
   tk-nuke: '@nuke.site'
+  tk-nukestudio: '@nuke.site'
   tk-desktop: '@desktop.site'
   tk-shell: '@shell.site'
   tk-photoshopcc: '@photoshopcc.site'

--- a/hooks/tk-multi-launchapp/before_register_command.py
+++ b/hooks/tk-multi-launchapp/before_register_command.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+class BeforeRegisterCommand(HookBaseClass):
+    """
+    Before Register Command Hook
+
+    This hook is run prior to launchapp registering launcher commands with
+    the parent engine. Note: this hook is only run for Software entity 
+    launchers.
+    """
+    def determine_engine_instance_name(self, software_version, engine_instance_name):
+        """
+        Hook method to intercept SoftwareLauncher and engine instance name data prior to
+        launcher command registration and alter the engine instance name should that
+        be required.
+
+        :param software_version: The software version instance constructed when
+            the scan software routine was run.
+        :type: :class:`sgtk.platform.SoftwareVersion`
+        :param str engine_instance_name: The name of the engine instance that will
+            be used when SGTK is bootstrapped during launch.
+
+        :returns: The desired engine instance name.
+        :rtype: str
+        """
+        # We're going to end up getting a SoftwareVersion for Nuke Studio that
+        # wants to route us to the tk-nuke engine instance. We don't want that, so
+        # we'll redirect to tk-nukestudio.
+        if software_version.product == "NukeStudio":
+            engine_instance_name = "tk-nukestudio"
+
+        return engine_instance_name
+


### PR DESCRIPTION
This allows us to configure Nuke Studio separately from Nuke. Specifically, we want to configure Nuke Studio without the quickreview app for project and shot environments.