### PR TITLE
For SG-5387: Adds clip import support for Nuke Studio.

### DIFF
--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -45,12 +45,12 @@ common.apps.tk-multi-publish2.location:
 common.apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
-  version: v1.18.4
+  version: v1.19.0
 
 common.apps.tk-multi-shotgunpanel.location:
   type: app_store
   name: tk-multi-shotgunpanel
-  version: v1.5.4
+  version: v1.6.0
 
 common.apps.tk-multi-launchapp.location:
   type: app_store

--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -33,6 +33,7 @@ desktop.project:
 
     tk-multi-launchapp:
       use_software_entity: true
+      hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
       location: "@common.apps.tk-multi-launchapp.location"
 
   collapse_rules:

--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -43,6 +43,38 @@ nuke.apps.tk-multi-publish2:
 nuke.apps.tk-multi-loader2:
   action_mappings:
     Alembic Cache: [read_node]
+    Flame Render: [read_node]
+    Flame Quicktime: [read_node]
+    Image: [read_node]
+    Movie: [read_node]
+    Nuke Script: [script_import]
+    NukeStudio Project: [open_project]
+    Photoshop Image: [read_node]
+    Rendered Image: [read_node]
+    Texture: [read_node]
+  actions_hook: '{self}/tk-nuke_actions.py'
+  entities:
+  - caption: Current Project
+    type: Hierarchy
+    root: "{context.project}"
+    publish_filters: []
+  - caption: My Tasks
+    type: Query
+    entity_type: Task
+    filters:
+    - [project, is, '{context.project}']
+    - [task_assignees, is, '{context.user}']
+    hierarchy: [entity, content]
+  # ignore publishes without a status. with zero config, it is very easy
+  # to publish the same path multiple times. the default zero config publish
+  # plugins will clear the status of previous publishes of the same path.
+  # this filter means only the latest publish will be displayed.
+  publish_filters: [["sg_status_list", "is_not", null]]
+  location: "@common.apps.tk-multi-loader2.location"
+
+nukestudio.apps.tk-multi-loader2:
+  action_mappings:
+    Alembic Cache: [read_node]
     Flame Render: [read_node, clip_import]
     Flame Quicktime: [read_node, clip_import]
     Image: [read_node, clip_import]
@@ -79,19 +111,55 @@ nuke.apps.tk-multi-shotgunpanel:
       filters: {published_file_type: Alembic Cache}
     - actions: [read_node]
       filters: {published_file_type: Image}
-    - actions: [read_node, clip_import]
+    - actions: [read_node]
       filters: {published_file_type: Movie}
-    - actions: [read_node, clip_import]
+    - actions: [read_node]
       filters: {published_file_type: Flame Render}
-    - actions: [read_node, clip_import]
+    - actions: [read_node]
       filters: {published_file_type: Flame Quicktime}
-    - actions: [script_import, clip_import]
+    - actions: [script_import]
       filters: {published_file_type: Nuke Script}
     - actions: [open_project]
       filters: {published_file_type: NukeStudio Project}
     - actions: [read_node]
       filters: {published_file_type: Photoshop Image}
     - actions: [read_node]
+      filters: {published_file_type: Rendered Image}
+    - actions: [read_node]
+      filters: {published_file_type: Texture}
+    - actions: [publish_clipboard]
+      filters: {}
+    Task:
+    - actions: [assign_task, task_to_ip]
+      filters: {}
+    Version:
+    - actions: [quicktime_clipboard, sequence_clipboard, add_to_playlist]
+      filters: {}
+
+  actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+  enable_context_switch: true
+  location: "@common.apps.tk-multi-shotgunpanel.location"
+
+nukestudio.apps.tk-multi-shotgunpanel:
+  action_mappings:
+    PublishedFile:
+    - actions: [read_node]
+      filters: {published_file_type: Alembic Cache}
+    - actions: [read_node, clip_import]
+      filters: {published_file_type: Image}
+    - actions: [read_node, clip_import]
+      filters: {published_file_type: Movie}
+    - actions: [read_node, clip_import]
+      filters: {published_file_type: Flame Render}
+    - actions: [read_node, clip_import]
+      filters: {published_file_type: Flame Quicktime}
+    - actions: [script_import]
+      filters: {published_file_type: Nuke Script}
+    - actions: [open_project]
+      filters: {published_file_type: NukeStudio Project}
+    - actions: [read_node]
+      filters: {published_file_type: Photoshop Image}
+    - actions: [read_node, clip_import]
       filters: {published_file_type: Rendered Image}
     - actions: [read_node, clip_import]
       filters: {published_file_type: Texture}

--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -43,14 +43,14 @@ nuke.apps.tk-multi-publish2:
 nuke.apps.tk-multi-loader2:
   action_mappings:
     Alembic Cache: [read_node]
-    Flame Render: [read_node]
-    Flame Quicktime: [read_node]
-    Image: [read_node]
-    Movie: [read_node]
+    Flame Render: [read_node, clip_import]
+    Flame Quicktime: [read_node, clip_import]
+    Image: [read_node, clip_import]
+    Movie: [read_node, clip_import]
     Nuke Script: [script_import]
     NukeStudio Project: [open_project]
     Photoshop Image: [read_node]
-    Rendered Image: [read_node]
+    Rendered Image: [read_node, clip_import]
     Texture: [read_node]
   actions_hook: '{self}/tk-nuke_actions.py'
   entities:
@@ -79,13 +79,13 @@ nuke.apps.tk-multi-shotgunpanel:
       filters: {published_file_type: Alembic Cache}
     - actions: [read_node]
       filters: {published_file_type: Image}
-    - actions: [read_node]
+    - actions: [read_node, clip_import]
       filters: {published_file_type: Movie}
-    - actions: [read_node]
+    - actions: [read_node, clip_import]
       filters: {published_file_type: Flame Render}
-    - actions: [read_node]
+    - actions: [read_node, clip_import]
       filters: {published_file_type: Flame Quicktime}
-    - actions: [script_import]
+    - actions: [script_import, clip_import]
       filters: {published_file_type: Nuke Script}
     - actions: [open_project]
       filters: {published_file_type: NukeStudio Project}
@@ -93,7 +93,7 @@ nuke.apps.tk-multi-shotgunpanel:
       filters: {published_file_type: Photoshop Image}
     - actions: [read_node]
       filters: {published_file_type: Rendered Image}
-    - actions: [read_node]
+    - actions: [read_node, clip_import]
       filters: {published_file_type: Texture}
     - actions: [publish_clipboard]
       filters: {}

--- a/env/includes/nuke/project.yml
+++ b/env/includes/nuke/project.yml
@@ -35,3 +35,22 @@ nuke.project:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
   launch_builtin_plugins: [basic]
   automatic_context_switch: false
+
+nukestudio.project:
+  apps:
+    tk-multi-about: '@common.apps.tk-multi-about'
+
+    tk-multi-publish2: '@nuke.apps.tk-multi-publish2'
+
+    tk-multi-loader2: '@nukestudio.apps.tk-multi-loader2'
+
+    tk-multi-shotgunpanel: '@nukestudio.apps.tk-multi-shotgunpanel'
+
+    tk-nuke-quickreview: '@nuke.apps.tk-nuke-quickreview'
+
+  location: "@common.engines.tk-nuke.location"
+  menu_favourites: []
+  run_at_startup:
+  - {app_instance: tk-multi-shotgunpanel, name: ''}
+  launch_builtin_plugins: [basic]
+  automatic_context_switch: false

--- a/env/includes/nuke/shot.yml
+++ b/env/includes/nuke/shot.yml
@@ -38,3 +38,24 @@ nuke.shot:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
   launch_builtin_plugins: [basic]
   automatic_context_switch: false
+
+nukestudio.shot:
+  apps:
+    tk-multi-about: '@common.apps.tk-multi-about'
+
+    tk-multi-setframerange: '@common.apps.tk-multi-setframerange'
+
+    tk-multi-publish2: '@nuke.apps.tk-multi-publish2'
+
+    tk-multi-loader2: '@nukestudio.apps.tk-multi-loader2'
+
+    tk-multi-shotgunpanel: '@nukestudio.apps.tk-multi-shotgunpanel'
+
+    tk-nuke-quickreview: '@nuke.apps.tk-nuke-quickreview'
+
+  location: "@common.engines.tk-nuke.location"
+  menu_favourites: []
+  run_at_startup:
+  - {app_instance: tk-multi-shotgunpanel, name: ''}
+  launch_builtin_plugins: [basic]
+  automatic_context_switch: false

--- a/env/includes/shell/apps.yml
+++ b/env/includes/shell/apps.yml
@@ -19,6 +19,7 @@ includes:
 
 shell.apps.tk-multi-launchapp:
   use_software_entity: true
+  hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
   location: "@common.apps.tk-multi-launchapp.location"
 
 shell.apps.tk-multi-publish2:

--- a/env/includes/shotgun/all.yml
+++ b/env/includes/shotgun/all.yml
@@ -31,6 +31,7 @@ shotgun.all:
     tk-multi-launchapp:
       scan_all_projects: true
       use_software_entity: true
+      hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
       location: "@common.apps.tk-multi-launchapp.location"
 
   location: "@common.engines.tk-shotgun.location"

--- a/env/project.yml
+++ b/env/project.yml
@@ -27,6 +27,7 @@ engines:
   tk-houdini: '@houdini.project'
   tk-maya: '@maya.project'
   tk-nuke: '@nuke.project'
+  tk-nukestudio: '@nukestudio.project'
   tk-desktop: '@desktop.project'
   tk-shell: '@shell.project'
   tk-photoshopcc: '@photoshopcc.project'

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -26,6 +26,7 @@ engines:
   tk-houdini: '@houdini.shot'
   tk-maya: '@maya.shot'
   tk-nuke: '@nuke.shot'
+  tk-nukestudio: '@nukestudio.shot'
   tk-flame: '@flame.shot'
   tk-shell: '@shell.shot'
   tk-photoshopcc: '@photoshopcc.shot'

--- a/env/site.yml
+++ b/env/site.yml
@@ -27,6 +27,7 @@ engines:
   tk-houdini: '@houdini.site'
   tk-maya: '@maya.site'
   tk-nuke: '@nuke.site'
+  tk-nukestudio: '@nuke.site'
   tk-desktop: '@desktop.site'
   tk-shell: '@shell.site'
   tk-photoshopcc: '@photoshopcc.site'

--- a/hooks/tk-multi-launchapp/before_register_command.py
+++ b/hooks/tk-multi-launchapp/before_register_command.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+class BeforeRegisterCommand(HookBaseClass):
+    """
+    Before Register Command Hook
+
+    This hook is run prior to launchapp registering launcher commands with
+    the parent engine. Note: this hook is only run for Software entity 
+    launchers.
+    """
+    def determine_engine_instance_name(self, software_version, engine_instance_name):
+        """
+        Hook method to intercept SoftwareLauncher and engine instance name data prior to
+        launcher command registration and alter the engine instance name should that
+        be required.
+
+        :param software_version: The software version instance constructed when
+            the scan software routine was run.
+        :type: :class:`sgtk.platform.SoftwareVersion`
+        :param str engine_instance_name: The name of the engine instance that will
+            be used when SGTK is bootstrapped during launch.
+
+        :returns: The desired engine instance name.
+        :rtype: str
+        """
+        # We're going to end up getting a SoftwareVersion for Nuke Studio that
+        # wants to route us to the tk-nuke engine instance. We don't want that, so
+        # we'll redirect to tk-nukestudio.
+        if software_version.product == "NukeStudio":
+            engine_instance_name = "tk-nukestudio"
+
+        return engine_instance_name


### PR DESCRIPTION
Same thing as what we did in tk-config-default2. This adds the clip_import action for appropriate publish types to loader2 and shotgunpanel apps for Nuke Studio.

Note: The bulk of these changes were reviewed and approved in #60. We didn't end up needing to go this route at that time, but it's being resurrected here with the addition of some actions being added to loader2 and shotgunpanel for Nuke Studio.