### PR TITLE
SG-9614 adds launch folder app to basic config on PublishedFiles

### DIFF
--- a/core/hooks/pick_environment.py
+++ b/core/hooks/pick_environment.py
@@ -21,6 +21,9 @@ class PickEnvironment(Hook):
 
     def execute(self, context, **kwargs):
 
+        if context.source_entity and context.source_entity["type"] == "PublishedFile":
+            return "publishedfile"
+
         if context.entity and context.entity["type"] == "Shot":
             return "shot"
 

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -62,6 +62,11 @@ common.apps.tk-nuke-quickreview.location:
   name: tk-nuke-quickreview
   version: v1.0.3
 
+common.apps.tk-shotgun-launchfolder.location:
+  type: app_store
+  name: tk-shotgun-launchfolder
+  version: v0.2.1
+
 # help urls
 
 common.apps.tk-multi-publish2.help_url: https://support.shotgunsoftware.com/hc/en-us/articles/115000068574-Integrations-User-Guide#The%20Publisher

--- a/env/includes/shotgun/all.yml
+++ b/env/includes/shotgun/all.yml
@@ -35,3 +35,11 @@ shotgun.all:
       location: "@common.apps.tk-multi-launchapp.location"
 
   location: "@common.engines.tk-shotgun.location"
+
+shotgun.publishedfile:
+  apps:
+
+    settings.tk-shotgun-launchfolder:
+      location: "@common.apps.tk-shotgun-launchfolder.location"
+
+  location: "@common.engines.tk-shotgun.location"

--- a/env/publishedfile.yml
+++ b/env/publishedfile.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Toolkit configuration to be loaded whenever an association with a
+             publishedfile has been established.
+
+includes:
+- includes/shotgun/all.yml
+
+engines:
+  tk-shotgun: '@shotgun.publishedfile'


### PR DESCRIPTION
This pull request adds the `tk-shotgun-launchfolder` app to the `PublishedFile` environment, due to the app's recent support for the entity type. Since it doesn't require schema support to open a path on a `PublishedFile` entity, I'm proposing adding it to the basic config.

In order to add it to the `PublishedFile` entity as an action menu item, I had to separate out the `PublishedFile` entity environment from the `project`.
The new `PublishedFile` entity environment is set to show only the Show in filesystem, removing the app launchers that were there previously. The app launchers didn't really make much sense in this context previously so I decided to remove them since I was branching. They didn't, for example, open the DCC with the selected `PublishedFile`, so I didn't see much use in having them in that list.