### PR TITLE
Update to flame v1.15.1

### DIFF
--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -51,7 +51,7 @@ common.engines.tk-aftereffects.location:
 common.engines.tk-flame.location:
   type: app_store
   name: tk-flame
-  version: v1.15.0
+  version: v1.15.1
 
 # Desktop
 common.engines.tk-desktop.location:

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -51,7 +51,7 @@ common.engines.tk-aftereffects.location:
 common.engines.tk-flame.location:
   type: app_store
   name: tk-flame
-  version: v1.14.9
+  version: v1.15.0
 
 # Desktop
 common.engines.tk-desktop.location:


### PR DESCRIPTION
JIRA: SMOK-51359
shot info is missing in Shotgun when published if "Create Open Clip" is disabled