### PR TITLE
Update to tk-flame v1.15.2

### DIFF
--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -51,7 +51,7 @@ common.engines.tk-aftereffects.location:
 common.engines.tk-flame.location:
   type: app_store
   name: tk-flame
-  version: v1.15.1
+  version: v1.15.2
 
 # Desktop
 common.engines.tk-desktop.location:


### PR DESCRIPTION
JIRA: SMOK-51684
Shotgun can submit backburner jobs with a job name that is too long, error on submission