### PR TITLE
VMR-2223, Open from web

### DIFF
--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -64,7 +64,7 @@ common.engines.tk-desktop2.location:
   type: git_branch
   branch: VMR-2223-open-from-web
   path: https://github.com/shotgunsoftware/tk-desktop2.git
-  version: 49c31c03ffa8eafb45d6834f29b689d0ff245bca
+  version: 354d705c9107afb346dc4e4634b3fe977f657964
   #type: dev
   #path: /Users/ohrstrm/dev/tk-desktop2
 

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -61,9 +61,10 @@ common.engines.tk-desktop.location:
 
 # Desktop2
 common.engines.tk-desktop2.location:
-  type: app_store
-  name: tk-desktop2
-  version: v1.1.0
+  type: git_branch
+  branch: master
+  path: https://github.com/shotgunsoftware/tk-desktop2.git
+  version: 3bfe3d4835ef757fb2365bc07b6b5a329d744b35
 
 # Shell
 common.engines.tk-shell.location:

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -64,7 +64,7 @@ common.engines.tk-desktop2.location:
   type: git_branch
   branch: VMR-2223-open-from-web
   path: https://github.com/shotgunsoftware/tk-desktop2.git
-  version: ac168826fd6e3d70820e00bff75889b40afe9dcb
+  version: ca40bcf0a979e2add650b4044e28b9470c39fe18
   #type: dev
   #path: /Users/ohrstrm/dev/tk-desktop2
 

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -64,7 +64,7 @@ common.engines.tk-desktop2.location:
   type: git_branch
   branch: VMR-2223-open-from-web
   path: https://github.com/shotgunsoftware/tk-desktop2.git
-  version: ca40bcf0a979e2add650b4044e28b9470c39fe18
+  version: 170d9178234c1f72850f947e531f835d76c54d16
   #type: dev
   #path: /Users/ohrstrm/dev/tk-desktop2
 

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -64,7 +64,7 @@ common.engines.tk-desktop2.location:
   type: git_branch
   branch: VMR-2223-open-from-web
   path: https://github.com/shotgunsoftware/tk-desktop2.git
-  version: 354d705c9107afb346dc4e4634b3fe977f657964
+  version: ac168826fd6e3d70820e00bff75889b40afe9dcb
   #type: dev
   #path: /Users/ohrstrm/dev/tk-desktop2
 

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -64,7 +64,9 @@ common.engines.tk-desktop2.location:
   type: git_branch
   branch: VMR-2223-open-from-web
   path: https://github.com/shotgunsoftware/tk-desktop2.git
-  version: 3bfe3d4835ef757fb2365bc07b6b5a329d744b35
+  version: 49c31c03ffa8eafb45d6834f29b689d0ff245bca
+  #type: dev
+  #path: /Users/ohrstrm/dev/tk-desktop2
 
 # Shell
 common.engines.tk-shell.location:

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -63,7 +63,7 @@ common.engines.tk-desktop.location:
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2
-  version:  v1.2.1
+  version: v1.2.1
 
 # Shell
 common.engines.tk-shell.location:

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -62,7 +62,7 @@ common.engines.tk-desktop.location:
 # Desktop2
 common.engines.tk-desktop2.location:
   type: git_branch
-  branch: master
+  branch: VMR-2223-open-from-web
   path: https://github.com/shotgunsoftware/tk-desktop2.git
   version: 3bfe3d4835ef757fb2365bc07b6b5a329d744b35
 

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -61,12 +61,9 @@ common.engines.tk-desktop.location:
 
 # Desktop2
 common.engines.tk-desktop2.location:
-  type: git_branch
-  branch: VMR-2223-open-from-web
-  path: https://github.com/shotgunsoftware/tk-desktop2.git
-  version: 170d9178234c1f72850f947e531f835d76c54d16
-  #type: dev
-  #path: /Users/ohrstrm/dev/tk-desktop2
+  type: app_store
+  name: tk-desktop2
+  version:  v1.2.1
 
 # Shell
 common.engines.tk-shell.location:


### PR DESCRIPTION
This upgrades to the most recent version of the desktop-2 engine, which adds more robust and extended websockets functionality to Shotgun Create.