### PR TITLE
Bump Shotgun Create engine

### DIFF
--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -63,7 +63,7 @@ common.engines.tk-desktop.location:
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2
-  version: v1.2.5
+  version: v1.3.0
 
 # Shell
 common.engines.tk-shell.location:


### PR DESCRIPTION
The engine update enable the support for the `sgc_open_version_draft` command and contains some certificate fixes required to be able to use tk-framework-desktopclient.