### PR TITLE
SG-14434: Switch to the new tk-3dsmax engine. #67

### DIFF
--- a/env/includes/3dsmax/apps.yml
+++ b/env/includes/3dsmax/apps.yml
@@ -38,7 +38,7 @@ includes:
     Image: [texture_node]
     Rendered Image: [texture_node]
     Texture: [texture_node]
-  actions_hook: '{self}/tk-3dsmaxplus_actions.py'
+  actions_hook: "{engine}/tk-multi-loader2/basic/scene_actions.py"
   download_thumbnails: true
   entities:
   - caption: Current Project
@@ -61,7 +61,7 @@ includes:
 
 3dsmax.apps.tk-multi-shotgunpanel:
   shotgun_fields_hook: '{self}/shotgun_fields.py'
-  actions_hook: '{self}/general_actions.py:{self}/tk-3dsmaxplus_actions.py'
+  actions_hook: "{engine}/tk-multi-shotgunpanel/basic/scene_actions.py"
   action_mappings:
     PublishedFile:
     - actions: [import]

--- a/env/includes/3dsmax/project.yml
+++ b/env/includes/3dsmax/project.yml
@@ -29,7 +29,7 @@ includes:
 
     tk-multi-shotgunpanel: '@3dsmax.apps.tk-multi-shotgunpanel'
 
-  location: "@common.engines.tk-3dsmaxplus.location"
+  location: "@common.engines.tk-3dsmax.location"
   menu_favourites: []
   launch_builtin_plugins: [basic]
 

--- a/env/includes/3dsmax/shot.yml
+++ b/env/includes/3dsmax/shot.yml
@@ -31,7 +31,7 @@ includes:
 
     tk-multi-shotgunpanel: '@3dsmax.apps.tk-multi-shotgunpanel'
 
-  location: "@common.engines.tk-3dsmaxplus.location"
+  location: "@common.engines.tk-3dsmax.location"
   menu_favourites: []
   launch_builtin_plugins: [basic]
 

--- a/env/includes/3dsmax/site.yml
+++ b/env/includes/3dsmax/site.yml
@@ -31,7 +31,7 @@ includes:
         Image: [texture_node]
         Rendered Image: [texture_node]
         Texture: [texture_node]
-      actions_hook: '{self}/tk-3dsmaxplus_actions.py'
+      actions_hook: '{self}/tk-3dsmax_actions.py'
       entities:
       - caption: Project
         type: Hierarchy
@@ -52,6 +52,6 @@ includes:
 
     tk-multi-shotgunpanel: '@3dsmax.apps.tk-multi-shotgunpanel'
 
-  location: "@common.engines.tk-3dsmaxplus.location"
+  location: "@common.engines.tk-3dsmax.location"
   menu_favourites: []
   launch_builtin_plugins: [basic]

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -45,7 +45,7 @@ common.apps.tk-multi-publish2.location:
 common.apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
-  version: v1.19.4
+  version: v1.19.5
 
 common.apps.tk-multi-shotgunpanel.location:
   type: app_store

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -12,10 +12,9 @@
 # locations for common engines
 
 # 3dsMax
-common.engines.tk-3dsmaxplus.location:
-  type: app_store
-  name: tk-3dsmaxplus
-  version: v0.5.8
+common.engines.tk-3dsmax.location:
+  type: dev
+  path: "$DEV_ROOT/gitlocal/tk-3dsmax"
 
 # Houdini
 common.engines.tk-houdini.location:

--- a/env/project.yml
+++ b/env/project.yml
@@ -35,6 +35,6 @@ engines:
   tk-shell: '@shell.project'
   tk-photoshopcc: '@photoshopcc.project'
   tk-aftereffects: '@aftereffects.project'
-  tk-3dsmaxplus: '@3dsmax.project'
+  tk-3dsmax: '@3dsmax.project'
   tk-shotgun: '@shotgun.all'
   tk-flame: '@flame.project'

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -34,5 +34,5 @@ engines:
   tk-shell: '@shell.shot'
   tk-photoshopcc: '@photoshopcc.shot'
   tk-aftereffects: '@aftereffects.shot'
-  tk-3dsmaxplus: '@3dsmax.shot'
+  tk-3dsmax: '@3dsmax.shot'
   tk-shotgun: '@shotgun.all'

--- a/env/site.yml
+++ b/env/site.yml
@@ -35,6 +35,6 @@ engines:
   tk-shell: '@shell.site'
   tk-photoshopcc: '@photoshopcc.site'
   tk-aftereffects: '@aftereffects.site'
-  tk-3dsmaxplus: '@3dsmax.site'
+  tk-3dsmax: '@3dsmax.site'
   tk-shotgun: '@shotgun.all'
 


### PR DESCRIPTION
This updates the configuration to use the new `tk-3dsmax` engine. It updates the descriptors of the engine and of the Toolkit applications used in `3dsMax`. It also updates the locations of the hooks.

See this [page](http://developer.shotgunsoftware.com/tk-3dsmax/migration.html) for more details.