### PR TITLE
Enable Set Work Area option for Shotgun Panel inside VRED

### DIFF
--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -97,4 +97,5 @@ vred.apps.tk-multi-shotgunpanel:
     Version:
     - actions: [quicktime_clipboard, sequence_clipboard, add_to_playlist]
       filters: {}
+  enable_context_switch: true
   location: "@common.apps.tk-multi-shotgunpanel.location"


### PR DESCRIPTION
Enabled the option enable_context_switch in the shotgun panel app for vred