### PR TITLE
[SHOT-3464] Improve Naming

### DIFF
--- a/env/includes/alias/apps.yml
+++ b/env/includes/alias/apps.yml
@@ -48,6 +48,8 @@ alias.apps.tk-multi-loader2:
     Fbx File: [import]
     Image: [texture_node]
     Photoshop Image: [texture_node]
+    Tif File: [texture_node]
+    Bmp File: [texture_node]
     Obj File: [import_subdiv]
     Tsm File: [import_subdiv]
     F3d File: [import_subdiv]
@@ -96,6 +98,10 @@ alias.apps.tk-multi-shotgunpanel:
       filters: {published_file_type: Image}
     - actions: [texture_node]
       filters: {published_file_type: Photoshop Image}
+    - actions: [texture_node]
+      filters: {published_file_type: Tif File}
+    - actions: [texture_node]
+      filters: {published_file_type: Bmp File}
     - actions: [import_subdiv]
       filters: {published_file_type: Obj File}
     - actions: [import_subdiv]


### PR DESCRIPTION
* Add action mappings for Alias loader and shotgunpanel: .tif and .bmp published file types to texture_node action