### PR TITLE
SHOT-3556: Add environment for Playlist entity type

### DIFF
--- a/core/hooks/pick_environment.py
+++ b/core/hooks/pick_environment.py
@@ -26,6 +26,8 @@ class PickEnvironment(Hook):
                 return "version"
             elif context.source_entity["type"] == "PublishedFile":
                 return "publishedfile"
+            elif context.source_entity["type"] == "Playlist":
+                return "playlist"
 
         if context.entity and context.step is None:
             # We have an entity but no step.

--- a/env/includes/shotgun/playlist.yml
+++ b/env/includes/shotgun/playlist.yml
@@ -21,7 +21,6 @@ shotgun.playlist:
   apps:
     settings.tk-shotgun-launchvredreview:
       deny_platforms: [ Mac, Linux ]
-      accepted_published_file_types: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
       hook_verify_install: "{self}/verify_install.py"
       hook_launch_publish: "{self}/shotgun_launch_vred.py"
       location: "@common.apps.tk-shotgun-launchvredreview.location"

--- a/env/includes/shotgun/playlist.yml
+++ b/env/includes/shotgun/playlist.yml
@@ -21,7 +21,7 @@ shotgun.playlist:
   apps:
     settings.tk-shotgun-launchvredreview:
       deny_platforms: [ Mac, Linux ]
-      accepted_published_file_types: [ VRED Scene ]
+      accepted_published_file_types: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
       hook_verify_install: "{self}/verify_install.py"
       hook_launch_publish: "{self}/shotgun_launch_vred.py"
       location: "@common.apps.tk-shotgun-launchvredreview.location"

--- a/env/includes/shotgun/playlist.yml
+++ b/env/includes/shotgun/playlist.yml
@@ -21,7 +21,7 @@ shotgun.playlist:
   apps:
     settings.tk-shotgun-launchvredreview:
       deny_platforms: [ Mac, Linux ]
-      viewer_extensions: [ vpb ]
+      accepted_published_file_types: [ VRED Scene ]
       hook_verify_install: "{self}/verify_install.py"
       hook_launch_publish: "{self}/shotgun_launch_vred.py"
       location: "@common.apps.tk-shotgun-launchvredreview.location"

--- a/env/includes/shotgun/playlist.yml
+++ b/env/includes/shotgun/playlist.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Autodesk, Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk, Inc.
+#
+
+# this configuration defines the behavior of the Shotgun Desktop when it
+# is running in its playlist level configuration
+
+includes:
+- ../common/engines.yml
+- ../common/apps.yml
+- ../common/frameworks.yml
+
+shotgun.playlist:
+  apps:
+    settings.tk-shotgun-launchvredreview:
+      deny_platforms: [ Mac, Linux ]
+      viewer_extensions: [ vpb ]
+      hook_verify_install: "{self}/verify_install.py"
+      hook_launch_publish: "{self}/shotgun_launch_vred.py"
+      location: "@common.apps.tk-shotgun-launchvredreview.location"
+  location: "@common.engines.tk-shotgun.location"

--- a/env/includes/shotgun/version.yml
+++ b/env/includes/shotgun/version.yml
@@ -36,7 +36,6 @@ shotgun.version:
 
     settings.tk-shotgun-launchvredreview:
       deny_platforms: [ Mac, Linux ]
-      accepted_published_file_types: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
       hook_verify_install: "{self}/verify_install.py"
       hook_launch_publish: "{self}/shotgun_launch_vred.py"
       location: "@common.apps.tk-shotgun-launchvredreview.location"

--- a/env/includes/shotgun/version.yml
+++ b/env/includes/shotgun/version.yml
@@ -36,7 +36,7 @@ shotgun.version:
 
     settings.tk-shotgun-launchvredreview:
       deny_platforms: [ Mac, Linux ]
-      viewer_extensions: [ vpb ]
+      accepted_published_file_types: [ VRED Scene ]
       hook_verify_install: "{self}/verify_install.py"
       hook_launch_publish: "{self}/shotgun_launch_vred.py"
       location: "@common.apps.tk-shotgun-launchvredreview.location"

--- a/env/includes/shotgun/version.yml
+++ b/env/includes/shotgun/version.yml
@@ -36,7 +36,7 @@ shotgun.version:
 
     settings.tk-shotgun-launchvredreview:
       deny_platforms: [ Mac, Linux ]
-      accepted_published_file_types: [ VRED Scene ]
+      accepted_published_file_types: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
       hook_verify_install: "{self}/verify_install.py"
       hook_launch_publish: "{self}/shotgun_launch_vred.py"
       location: "@common.apps.tk-shotgun-launchvredreview.location"

--- a/env/includes/shotgun/version.yml
+++ b/env/includes/shotgun/version.yml
@@ -15,6 +15,7 @@
 includes:
 - ../common/engines.yml
 - ../common/apps.yml
+- ../common/frameworks.yml
 - ../common/settings/tk-multi-publish2.yml
 
 shotgun.version:

--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -73,6 +73,8 @@ vred.apps.tk-multi-loader2:
 
 vred.apps.tk-multi-shotgunpanel:
   actions_hook: "{engine}/tk-multi-shotgunpanel/basic/scene_actions.py"
+  shotgun_fields_hook: "{self}/shotgun_fields.py:{engine}/tk-multi-shotgunpanel/basic/shotgun_fields.py"
+  shotgun_filters_hook: "{engine}/tk-multi-shotgunpanel/basic/shotgun_filters.py"
   action_mappings:
     PublishedFile:
     - actions: [import]
@@ -99,7 +101,7 @@ vred.apps.tk-multi-shotgunpanel:
     - actions: [assign_task, task_to_ip]
       filters: {}
     Version:
-    - actions: [quicktime_clipboard, sequence_clipboard, add_to_playlist]
+    - actions: [quicktime_clipboard, sequence_clipboard, add_to_playlist, load_for_review]
       filters: {}
   enable_context_switch: true
   location: "@common.apps.tk-multi-shotgunpanel.location"

--- a/env/includes/vred/project.yml
+++ b/env/includes/vred/project.yml
@@ -32,5 +32,6 @@ vred.project:
   menu_favourites: []
   run_at_startup:
   - {app_instance: tk-multi-shotgunpanel, name: ''}
+  accepted_published_file_types: [ VRED Scene, Alias File, Catpart File, Jt File, Igs File ]
   launch_builtin_plugins: [basic]
   automatic_context_switch: false

--- a/env/playlist.yml
+++ b/env/playlist.yml
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Autodesk, Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk, Inc.
+#
+
+description: Toolkit configuration to be loaded whenever an association with a
+             Playlist has been established.
+
+includes:
+- includes/shotgun/playlist.yml
+- includes/vred/project.yml
+
+
+engines:
+  tk-shotgun: '@shotgun.playlist'
+  tk-vred: '@vred.project'


### PR DESCRIPTION
Support Playlist entity type out of the box:
* Add `env/playlist.yml` and `env/includes/shotgun/playlist.yml1 files
* Add handling in `pick_environment.py` for the Playlist entity type

Added new hook to tk-multi-shotgunpanel: `shotgun_filters_hook`, introduced in PR: https://github.com/shotgunsoftware/tk-multi-shotgunpanel/pull/50

Updated config specific to VRED.