### PR TITLE
Update tk-framework-desktopclient

### DIFF
--- a/env/includes/common/frameworks.yml
+++ b/env/includes/common/frameworks.yml
@@ -47,9 +47,9 @@ frameworks:
       version: v1.5.1
       type: app_store
       name: tk-framework-desktopserver
-  tk-framework-desktopclient_v0.x.x:
+  tk-framework-desktopclient_v1.x.x:
     location:
-      version: v0.2.0
+      version: v1.0.0
       type: app_store
       name: tk-framework-desktopclient
   tk-framework-aliastranslations_v0.x.x:


### PR DESCRIPTION
For some reason, the automatic version bump didn't work. Might be because of the major version bump?