### PR TITLE
SG-20204 Remove Softimage Support on February 13th

### DIFF
--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -52,7 +52,6 @@ desktop.project:
     - '*After*'
     - '*Effects*'
     - 'CC*'
-    - '*Softimage*'
     name: Creative Tools
   - matches:
     - '*Hiero*'


### PR DESCRIPTION
Remove Softimage from creative tools matches, because it will not be supported anymore.