### PR TITLE
SHOT-3905: Update config settings for Alias/VRED upload version publish plugin

### DIFF
--- a/env/includes/alias/apps.yml
+++ b/env/includes/alias/apps.yml
@@ -28,10 +28,10 @@ alias.apps.tk-multi-publish2:
   - name: Publish to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings: {}
-  - name: Create 3D Version for Review
+  - name: Create Version for Review
     hook: "{self}/upload_version.py:{engine}/tk-multi-publish2/basic/upload_version.py"
     settings:
-      3D Version: False
+      Version Type: 2D Version
   - name: Publish Variants to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_variants.py"
     settings: {}

--- a/env/includes/alias/apps.yml
+++ b/env/includes/alias/apps.yml
@@ -31,7 +31,7 @@ alias.apps.tk-multi-publish2:
   - name: Create 3D Version for Review
     hook: "{self}/upload_version.py:{engine}/tk-multi-publish2/basic/upload_version.py"
     settings:
-      3D Version: True
+      3D Version: False
   - name: Publish Variants to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_variants.py"
     settings: {}

--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -28,10 +28,10 @@ vred.apps.tk-multi-publish2:
   - name: Publish to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings: {}
-  - name: Create 2D Version for Review
+  - name: Create Version for Review
     hook: "{self}/upload_version.py:{engine}/tk-multi-publish2/basic/upload_session_version.py"
     settings:
-      3D Version: False
+      Version Type: 2D Version
   - name: Publish Rendering to ShotGrid
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_rendering.py"
     settings: {}


### PR DESCRIPTION
Replace 3D Version boolean config setting with Version Type string config setting, where Version Type is just the default value (e.g. 2D Version or 3D Version) and this option is then editable via the UI