### PR TITLE
SG-27405 Add Photoshop PNG And JPG Publish to configs.

### DIFF
--- a/env/includes/photoshopcc/apps.yml
+++ b/env/includes/photoshopcc/apps.yml
@@ -32,6 +32,19 @@ photoshopcc.apps.tk-multi-publish2:
     - name: Upload for review
       hook: "{engine}/tk-multi-publish2/basic/upload_version.py"
       settings: {}
+    - name: Publish PNG to Shotgun
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_image.py"
+      settings:
+        Export Settings:
+          format: PNG
+          PNG8: False
+          quality: 100
+    - name: Publish JPEG to Shotgun
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_image.py"
+      settings:
+        Export Settings:
+          format: JPEG
+          quality: 100
   location: "@common.apps.tk-multi-publish2.location"
 
 photoshopcc.apps.tk-multi-loader2:


### PR DESCRIPTION
Add new publish plugin to photoshop engine in order to export PSD as images and publish them to ShotGrid.