### PR TITLE
Fixes the yaml

### DIFF
--- a/env/includes/alias/apps.yml
+++ b/env/includes/alias/apps.yml
@@ -89,7 +89,7 @@ alias.apps.tk-multi-shotgunpanel:
   actions_hook: "{engine}/tk-multi-shotgunpanel/basic/scene_actions.py"
   action_mappings:
     Note:
-    - actions: [ note_to_ip, note_to_closed ]
+    - actions: [ note_to_ip, note_to_closed, import_note_attachments ]
       filters: { }
     PublishedFile:
     - actions: [import, import_as_reference]
@@ -135,9 +135,6 @@ alias.apps.tk-multi-shotgunpanel:
       filters: {}
     Version:
     - actions: [quicktime_clipboard, sequence_clipboard, add_to_playlist]
-      filters: {}
-    Note:
-    - actions: [import_note_attachments]
       filters: {}
   enable_context_switch: true
   location: "@common.apps.tk-multi-shotgunpanel.location"

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -72,5 +72,5 @@ common.apps.tk-shotgun-launchvredreview.location:
   type: app_store
   name: tk-shotgun-launchvredreview
   version: v1.1.4
-common.apps.tk-multi-publish2.help_url: 
+common.apps.tk-multi-publish2.help_url:
   https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Supervisor_Artist_sa_integrations_sa_integrations_user_guide_html#the-publisher

--- a/env/includes/common/frameworks.yml
+++ b/env/includes/common/frameworks.yml
@@ -72,4 +72,3 @@ frameworks:
       version: v1.0.0
       type: app_store
       name: tk-framework-lmv
-


### PR DESCRIPTION
Fixes 

``` 
2024-01-18T19:02:15.0902560Z ##[section]Starting: Updating tk-config-basic
2024-01-18T19:02:15.0918460Z ==============================================================================
2024-01-18T19:02:15.0919260Z Task         : Bash
2024-01-18T19:02:15.0919500Z Description  : Run a Bash script on macOS, Linux, or Windows
2024-01-18T19:02:15.0920350Z Version      : 3.231.5
2024-01-18T19:02:15.0921410Z Author       : Microsoft Corporation
2024-01-18T19:02:15.0921880Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/bash
2024-01-18T19:02:15.0922540Z ==============================================================================
2024-01-18T19:02:15.2572410Z Generating script.
2024-01-18T19:02:15.2602950Z ========================== Starting Command Output ===========================
2024-01-18T19:02:15.2607070Z [command]/bin/bash /Users/runner/work/_temp/a0651abb-df00-4e23-93d4-74a531bfbc24.sh
2024-01-18T19:02:15.4389190Z Cloning into '/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/tmptio6hn40'...
2024-01-18T19:02:17.6030960Z Updated '/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/tmptio6hn40/core/core_api.yml'
2024-01-18T19:02:17.6224790Z Traceback (most recent call last):
2024-01-18T19:02:17.6225860Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/bin/tk-config-update", line 8, in <module>
2024-01-18T19:02:17.6226560Z     sys.exit(main())
2024-01-18T19:02:17.6227460Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py", line 248, in main
2024-01-18T19:02:17.6228350Z     for yml_file in update_files(repo.root, bundle, version):
2024-01-18T19:02:17.6230260Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py", line 216, in update_files
2024-01-18T19:02:17.6231490Z     yaml_data = _yaml.load(fh)
2024-01-18T19:02:17.6232280Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/main.py", line 451, in load
2024-01-18T19:02:17.6232930Z     return constructor.get_single_data()
2024-01-18T19:02:17.6233720Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 114, in get_single_data
2024-01-18T19:02:17.6234320Z     return self.construct_document(node)
2024-01-18T19:02:17.6235560Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 123, in construct_document
2024-01-18T19:02:17.6236160Z     for _dummy in generator:
2024-01-18T19:02:17.6236900Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 1470, in construct_yaml_map
2024-01-18T19:02:17.6237530Z     self.construct_mapping(node, data, deep=True)
2024-01-18T19:02:17.6238280Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 1359, in construct_mapping
2024-01-18T19:02:17.6238970Z     value = self.construct_object(value_node, deep=deep)
2024-01-18T19:02:17.6240000Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 145, in construct_object
2024-01-18T19:02:17.6240690Z     data = self.construct_non_recursive_object(node)
2024-01-18T19:02:17.6241470Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 186, in construct_non_recursive_object
2024-01-18T19:02:17.6242120Z     for _dummy in generator:
2024-01-18T19:02:17.6243150Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 1470, in construct_yaml_map
2024-01-18T19:02:17.6243780Z     self.construct_mapping(node, data, deep=True)
2024-01-18T19:02:17.6244530Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 1359, in construct_mapping
2024-01-18T19:02:17.6245550Z     value = self.construct_object(value_node, deep=deep)
2024-01-18T19:02:17.6246780Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 145, in construct_object
2024-01-18T19:02:17.6247420Z     data = self.construct_non_recursive_object(node)
2024-01-18T19:02:17.6248200Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 186, in construct_non_recursive_object
2024-01-18T19:02:17.6248850Z     for _dummy in generator:
2024-01-18T19:02:17.6249580Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 1470, in construct_yaml_map
2024-01-18T19:02:17.6250420Z     self.construct_mapping(node, data, deep=True)
2024-01-18T19:02:17.6251240Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 1360, in construct_mapping
2024-01-18T19:02:17.6251930Z     if self.check_mapping_key(node, key_node, maptyp, key, value):
2024-01-18T19:02:17.6252710Z   File "/Users/runner/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/ruamel/yaml/constructor.py", line 276, in check_mapping_key
2024-01-18T19:02:17.6253310Z     raise DuplicateKeyError(*args)
2024-01-18T19:02:17.6253840Z ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping
2024-01-18T19:02:17.6254460Z   in "/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/tmptio6hn40/env/includes/alias/apps.yml", line 91, column 5
2024-01-18T19:02:17.6255820Z found duplicate key "Note" with value "[{'actions': ['import_note_attachments'], 'filters': {}}]" (original value: "[{'actions': ['note_to_ip', 'note_to_closed'], 'filters': {}}]")
2024-01-18T19:02:17.6256580Z   in "/var/folders/mm/pltwc2yj1jx192t6dzy9zsrr0000gn/T/tmptio6hn40/env/includes/alias/apps.yml", line 139, column 5
2024-01-18T19:02:17.6256970Z 
2024-01-18T19:02:17.6257300Z To suppress this check see:
2024-01-18T19:02:17.6257850Z     http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys
2024-01-18T19:02:17.6258160Z 
2024-01-18T19:02:17.6372970Z 
2024-01-18T19:02:17.6449350Z ##[error]Bash exited with code '1'.
2024-01-18T19:02:17.6474290Z ##[section]Finishing: Updating tk-config-basic
```