### PR TITLE
SHOT-4426: Create Smart Reference action only for native VRED file types

### DIFF
--- a/env/includes/vred/apps.yml
+++ b/env/includes/vred/apps.yml
@@ -42,14 +42,14 @@ vred.apps.tk-multi-publish2:
 
 vred.apps.tk-multi-loader2:
   action_mappings:
-    Alias File: [import, import_with_options, smart_reference]
-    Igs File: [import, import_with_options, smart_reference]
-    Stp File: [import, import_with_options, smart_reference]
-    Stl File: [import, import_with_options, smart_reference]
-    Jt File: [import, import_with_options, smart_reference]
-    Catpart File: [import, import_with_options, smart_reference]
-    Fbx File: [import, import_with_options, smart_reference]
-    Motion Builder FBX: [import, import_with_options, smart_reference]
+    Alias File: [import, import_with_options]
+    Igs File: [import, import_with_options]
+    Stp File: [import, import_with_options]
+    Stl File: [import, import_with_options]
+    Jt File: [import, import_with_options]
+    Catpart File: [import, import_with_options]
+    Fbx File: [import, import_with_options]
+    Motion Builder FBX: [import, import_with_options]
     VRED Scene: [import, import_with_options, smart_reference]
     Osb File: [import, import_with_options, smart_reference]
     Image: [ import_sceneplate ]
@@ -88,21 +88,21 @@ vred.apps.tk-multi-shotgunpanel:
     - actions: [ note_to_ip, note_to_closed ]
       filters: { }
     PublishedFile:
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Alias File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Igs File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Stp File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Stl File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Jt File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Catpart File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Fbx File}
-    - actions: [import, import_with_options, smart_reference]
+    - actions: [import, import_with_options]
       filters: {published_file_type: Motion Builder FBX}
     - actions: [import, import_with_options, smart_reference]
       filters: {published_file_type: VRED Scene}


### PR DESCRIPTION
* VRED smart references only work for native VRED files (e.g. .vpb, .osb)
* Only allow 'Create Smart Reference' for those supported file types (for loader and SG panel apps)