### PR TITLE
SG-41825: Fix invalid tk-desktop version format

### DIFF
--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -50,7 +50,7 @@ common.engines.tk-vred.location:
 common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
-  version: v.2.8.1
+  version: v2.8.1
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2


### PR DESCRIPTION
## Summary

Fixed invalid version format for tk-desktop engine from `v.2.8.1` to `v2.8.1` (removed extra dot after 'v').

This change corrects a typo in the engine version specification that could cause issues with version parsing and App Store resolution.

## Related Changes

- Companion PR in tk-config-default2: https://github.com/shotgunsoftware/tk-config-default2/pull/190

## Test Plan

- [x] Verify the configuration loads without errors
- [x] Confirm tk-desktop v2.8.1 resolves correctly from App Store
- [x] Check that existing workflows remain functional