### PR TITLE
SG-43667 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -35,7 +35,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -17,3 +17,4 @@ description: "Zero configuration Flow Production Tracking Toolkit workflow."
 # Required minimum versions for this item to run
 requires_shotgun_version: "v7.2.0"
 requires_core_version: "v0.19.18"
+minimum_python_version: "3.9"


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: "3.9"` in `info.yml`

## Test plan

- [ ] Config loads correctly with Python 3.9+

🤖 Generated with [Claude Code](https://claude.com/claude-code)