### PR TITLE
SG-43811 Add new Nuke publish hooks for handling FlowWrite renders

### DIFF
--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -21,8 +21,10 @@ nuke.apps.tk-multi-publish2:
   help_url: "@common.apps.tk-multi-publish2.help_url"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   publish_plugins:
-    - '@common.settings.tk-multi-publish2.publish_file'
     - '@common.settings.tk-multi-publish2.upload_version'
+    - name: Publish to Flow Production Tracking        # replaces '@common.settings.tk-multi-publish2.publish_file'
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_file.py"
+      settings: {}
     - name: Begin file versioning
       hook: "{engine}/tk-multi-publish2/basic/nuke_start_version_control.py"
       settings: {}
@@ -31,6 +33,9 @@ nuke.apps.tk-multi-publish2:
       settings: {}
     - name: Publish to Flow Production Tracking
       hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_script.py"
+      settings: {}
+    - name: Publish FlowWrite Renders to Flow AM
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_flow_write_publish_script.py"
       settings: {}
     - name: Publish to Flow Production Tracking
       hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nukestudio_publish_project.py"


### PR DESCRIPTION
DO NOT MERGE

This PR adds new Nuke publish hooks for handling renders from new FlowWrite node.
Since this requires the latest version of Nuke, do not merge until Flow integration has been formally released.