### PR TITLE
SG-43958 Expose loader in desktop with flowam actions

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -15,3 +15,8 @@ location:
   type: app_store
   name: tk-core
   version: v0.23.9
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 0df22bc70fd8bc15b1d26a2ea82a87e8220b9e60

--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -15,7 +15,7 @@ location:
   type: app_store
   name: tk-core
   version: v0.23.9
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-core.git

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -40,7 +40,7 @@ common.apps.tk-multi-publish2.location:
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-publish2.git
-  version: 2c4730b79ed201a47a5db248ca05c405a3ce15d3
+  version: f2317513ac756b47e4f855663567875a58a9528c
 common.apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
@@ -49,7 +49,7 @@ common.apps.tk-multi-loader2.location:
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-loader2.git
-  version: ccae09491a39dc5d58e3733cbfa191baf1babb64
+  version: 653474e14d81a3636a0c853c8ffd0246bd935fcf
 common.apps.tk-multi-breakdown2.location:
   type: app_store
   name: tk-multi-breakdown2

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -36,7 +36,7 @@ common.apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
   version: v2.11.0
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-publish2.git
@@ -45,7 +45,7 @@ common.apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
   version: v1.25.6
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-loader2.git
@@ -54,7 +54,7 @@ common.apps.tk-multi-breakdown2.location:
   type: app_store
   name: tk-multi-breakdown2
   version: v0.4.5
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-breakdown2.git

--- a/env/includes/common/apps.yml
+++ b/env/includes/common/apps.yml
@@ -36,10 +36,29 @@ common.apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
   version: v2.11.0
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-multi-publish2.git
+  version: 2c4730b79ed201a47a5db248ca05c405a3ce15d3
 common.apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
   version: v1.25.6
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-multi-loader2.git
+  version: ccae09491a39dc5d58e3733cbfa191baf1babb64
+common.apps.tk-multi-breakdown2.location:
+  type: app_store
+  name: tk-multi-breakdown2
+  version: v0.4.5
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-multi-breakdown2.git
+  version: cd2ca679891979d4de440c2c78ccd33766111f84
 common.apps.tk-multi-shotgunpanel.location:
   type: app_store
   name: tk-multi-shotgunpanel

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -22,7 +22,7 @@ common.engines.tk-houdini.location:
   # REMOVEME: Get latest branch from it is released
   type: git_branch
   branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
+  path: git@github.com:shotgunsoftware/tk-houdini.git
   version: 13a898c4b32289f0f11be5ddf54d141719384c21
 common.engines.tk-maya.location:
   type: app_store
@@ -31,7 +31,7 @@ common.engines.tk-maya.location:
   # REMOVEME: Get latest branch from it is released
   type: git_branch
   branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
+  path: git@github.com:shotgunsoftware/tk-maya.git
   version: 6b279ec303fd5e76699b6d206e34198872fd5280
 common.engines.tk-nuke.location:
   type: app_store
@@ -40,7 +40,7 @@ common.engines.tk-nuke.location:
   # REMOVEME: Get latest branch from it is released
   type: git_branch
   branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
+  path: git@github.com:shotgunsoftware/tk-nuke.git
   version: 02808561cd29466fa6a3aca0e8249b99868e2a47
 common.engines.tk-photoshopcc.location:
   type: app_store

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -19,14 +19,29 @@ common.engines.tk-houdini.location:
   type: app_store
   name: tk-houdini
   version: v1.9.12
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 13a898c4b32289f0f11be5ddf54d141719384c21
 common.engines.tk-maya.location:
   type: app_store
   name: tk-maya
   version: v0.13.11
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 6b279ec303fd5e76699b6d206e34198872fd5280
 common.engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
   version: v0.16.4
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 02808561cd29466fa6a3aca0e8249b99868e2a47
 common.engines.tk-photoshopcc.location:
   type: app_store
   name: tk-photoshopcc
@@ -51,6 +66,11 @@ common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
   version: v2.8.6
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-desktop.git
+  version: c528bccf01fc1c35e1f676f70bf532a42273b1b6
 common.engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2

--- a/env/includes/common/engines.yml
+++ b/env/includes/common/engines.yml
@@ -19,7 +19,7 @@ common.engines.tk-houdini.location:
   type: app_store
   name: tk-houdini
   version: v1.9.12
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-houdini.git
@@ -28,7 +28,7 @@ common.engines.tk-maya.location:
   type: app_store
   name: tk-maya
   version: v0.13.11
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-maya.git
@@ -37,7 +37,7 @@ common.engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
   version: v0.16.4
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-nuke.git
@@ -66,7 +66,7 @@ common.engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
   version: v2.8.6
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-desktop.git

--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -36,6 +36,34 @@ desktop.project:
       hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
       location: "@common.apps.tk-multi-launchapp.location"
 
+    tk-multi-loader2:
+      location: "@common.apps.tk-multi-loader2.location"
+      action_mappings:
+        # DCC file types can only be published within DCC to avoid data corruption
+        Maya Workfile: [download, reference_copy_link]
+        Nuke Workfile: [download, reference_copy_link]
+        Houdini Workfile: [download, reference_copy_link]
+        All: [download, publish, reference_copy_link]
+      entity_mappings:
+        Task: [create_generic_asset]
+        Project: [create_generic_asset]
+      entities:
+        - caption: Current Project
+          type: Query
+          entity_type: Project
+          publish_filters: []
+          filters:
+          - ["id", "is", "{context.project.id}"]
+          hierarchy: [name]
+        - caption: My Tasks
+          type: Query
+          entity_type: Task
+          publish_filters: []
+          filters:
+          - [task_assignees, is, "{context.user}"]
+          - ["project", "is", "{context.project}"]
+          hierarchy: [entity, content]
+
   collapse_rules:
   - {button_label: $app, match: Launch $app, menu_label: None}
   default_group: Studio

--- a/env/includes/desktop/project.yml
+++ b/env/includes/desktop/project.yml
@@ -38,15 +38,6 @@ desktop.project:
 
     tk-multi-loader2:
       location: "@common.apps.tk-multi-loader2.location"
-      action_mappings:
-        # DCC file types can only be published within DCC to avoid data corruption
-        Maya Workfile: [download, reference_copy_link]
-        Nuke Workfile: [download, reference_copy_link]
-        Houdini Workfile: [download, reference_copy_link]
-        All: [download, publish, reference_copy_link]
-      entity_mappings:
-        Task: [create_generic_asset]
-        Project: [create_generic_asset]
       entities:
         - caption: Current Project
           type: Query

--- a/env/includes/houdini/apps.yml
+++ b/env/includes/houdini/apps.yml
@@ -29,6 +29,9 @@ houdini.apps.tk-multi-publish2:
     - name: Publish to Flow Production Tracking
       hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
       settings: {}
+    - name: Publish Alembic Derivative
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py:{self}/flowam/publish_alembic_derivative.py"
+      settings: {}
   location: "@common.apps.tk-multi-publish2.location"
 
 houdini.apps.tk-multi-loader2:

--- a/env/includes/houdini/apps.yml
+++ b/env/includes/houdini/apps.yml
@@ -93,3 +93,7 @@ houdini.apps.tk-multi-shotgunpanel:
         filters: {}
     enable_context_switch: true
     location: "@common.apps.tk-multi-shotgunpanel.location"
+
+houdini.apps.tk-multi-breakdown2:
+  location: "@common.apps.tk-multi-breakdown2.location"
+  panel_mode: False

--- a/env/includes/houdini/asset_step.yml
+++ b/env/includes/houdini/asset_step.yml
@@ -28,6 +28,8 @@ houdini.asset_step:
 
     tk-multi-shotgunpanel: '@houdini.apps.tk-multi-shotgunpanel'
 
+    tk-multi-breakdown2: '@houdini.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-houdini.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/houdini/project.yml
+++ b/env/includes/houdini/project.yml
@@ -28,6 +28,8 @@ houdini.project:
 
     tk-multi-shotgunpanel: '@houdini.apps.tk-multi-shotgunpanel'
 
+    tk-multi-breakdown2: '@houdini.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-houdini.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/houdini/shot_step.yml
+++ b/env/includes/houdini/shot_step.yml
@@ -30,6 +30,8 @@ houdini.shot_step:
 
     tk-multi-shotgunpanel: '@houdini.apps.tk-multi-shotgunpanel'
 
+    tk-multi-breakdown2: '@houdini.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-houdini.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/maya/apps.yml
+++ b/env/includes/maya/apps.yml
@@ -28,6 +28,9 @@ maya.apps.tk-multi-publish2:
   - name: Publish to Flow Production Tracking
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings: {}
+  - name: Publish Alembic Derivative
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py:{self}/flowam/publish_alembic_derivative.py"
+    settings: {}
   location: "@common.apps.tk-multi-publish2.location"
 
 maya.apps.tk-multi-loader2:

--- a/env/includes/maya/apps.yml
+++ b/env/includes/maya/apps.yml
@@ -93,3 +93,7 @@ maya.apps.tk-multi-reviewsubmission:
   render_media_hook: '{self}/render_media.py:{self}/{engine_name}/render_media.py'
   submitter_hook: '{self}/submitter_create.py'
   location: "@common.apps.tk-multi-reviewsubmission.location"
+
+maya.apps.tk-multi-breakdown2:
+  location: "@common.apps.tk-multi-breakdown2.location"
+  panel_mode: False

--- a/env/includes/maya/asset_step.yml
+++ b/env/includes/maya/asset_step.yml
@@ -29,6 +29,8 @@ maya.asset_step:
 
     tk-multi-reviewsubmission: '@maya.apps.tk-multi-reviewsubmission'
 
+    tk-multi-breakdown2: '@maya.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-maya.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/maya/project.yml
+++ b/env/includes/maya/project.yml
@@ -28,6 +28,8 @@ maya.project:
 
     tk-multi-shotgunpanel: '@maya.apps.tk-multi-shotgunpanel'
 
+    tk-multi-breakdown2: '@maya.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-maya.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/maya/shot_step.yml
+++ b/env/includes/maya/shot_step.yml
@@ -31,6 +31,8 @@ maya.shot_step:
 
     tk-multi-reviewsubmission: '@maya.apps.tk-multi-reviewsubmission'
 
+    tk-multi-breakdown2: '@maya.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-maya.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -181,3 +181,7 @@ nukestudio.apps.tk-multi-shotgunpanel:
 
 nuke.apps.tk-nuke-quickreview:
   location: "@common.apps.tk-nuke-quickreview.location"
+
+nuke.apps.tk-multi-breakdown2:
+  location: "@common.apps.tk-multi-breakdown2.location"
+  panel_mode: False

--- a/env/includes/nuke/apps.yml
+++ b/env/includes/nuke/apps.yml
@@ -21,8 +21,10 @@ nuke.apps.tk-multi-publish2:
   help_url: "@common.apps.tk-multi-publish2.help_url"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   publish_plugins:
-    - '@common.settings.tk-multi-publish2.publish_file'
     - '@common.settings.tk-multi-publish2.upload_version'
+    - name: Publish to Flow Production Tracking        # replaces '@common.settings.tk-multi-publish2.publish_file'
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_file.py"
+      settings: {}
     - name: Begin file versioning
       hook: "{engine}/tk-multi-publish2/basic/nuke_start_version_control.py"
       settings: {}
@@ -31,6 +33,9 @@ nuke.apps.tk-multi-publish2:
       settings: {}
     - name: Publish to Flow Production Tracking
       hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_script.py"
+      settings: {}
+    - name: Publish FlowWrite Renders to Flow AM
+      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_flow_write_publish_script.py"
       settings: {}
     - name: Publish to Flow Production Tracking
       hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nukestudio_publish_project.py"

--- a/env/includes/nuke/asset_step.yml
+++ b/env/includes/nuke/asset_step.yml
@@ -29,6 +29,8 @@ nuke.asset_step:
 
     tk-nuke-quickreview: '@nuke.apps.tk-nuke-quickreview'
 
+    tk-multi-breakdown2: '@nuke.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-nuke.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/nuke/project.yml
+++ b/env/includes/nuke/project.yml
@@ -29,6 +29,8 @@ nuke.project:
 
     tk-nuke-quickreview: '@nuke.apps.tk-nuke-quickreview'
 
+    tk-multi-breakdown2: '@nuke.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-nuke.location"
   menu_favourites: []
   run_at_startup:

--- a/env/includes/nuke/shot_step.yml
+++ b/env/includes/nuke/shot_step.yml
@@ -32,6 +32,8 @@ nuke.shot_step:
 
     tk-nuke-quickreview: '@nuke.apps.tk-nuke-quickreview'
 
+    tk-multi-breakdown2: '@nuke.apps.tk-multi-breakdown2'
+
   location: "@common.engines.tk-nuke.location"
   menu_favourites: []
   run_at_startup:


### PR DESCRIPTION
Branch for feature testing

## Differences from production release

1. Unreleased descriptors for core, engines, and apps
2. Show the loader in the FPT desktop the same way as the publisher is displayed.
3. Register the FlowAM alembic derivative publish plugin in the Houdini and Maya publish_plugins lists (asset_step and shot_step)
4. Add Scene Breakdown to Maya, Houdini, and Nuke on project, asset_step, and shot_step contexts.